### PR TITLE
Add toolbar select from settings.json

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,6 +4,7 @@
       "name": "main",
       "client_hooks": {
         "postAceInit": "ep_font_size/static/js/index",
+        "postToolbarInit": "ep_font_size/static/js/index",
         "aceInitialized": "ep_font_size/static/js/index",
         "aceEditorCSS": "ep_font_size/static/js/index",
         "aceCreateDomLine": "ep_font_size/static/js/index",
@@ -11,6 +12,7 @@
         "collectContentPre": "ep_font_size/static/js/shared"
       },
       "hooks": {
+        "padInitToolbar": "ep_font_size/index",
         "eejsBlock_editbarMenuLeft": "ep_font_size/index",
         "collectContentPre": "ep_font_size/static/js/shared",
         "collectContentPost": "ep_font_size/static/js/shared",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 const eejs = require('ep_etherpad-lite/node/eejs/');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
+
 exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
+  if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1 ) {
+    return cb();
+  }
   args.content += eejs.require('ep_font_size/templates/editbarButtons.ejs');
   return cb();
 };
@@ -11,5 +16,22 @@ exports.eejsBlock_dd_format = function (hook_name, args, cb) {
 
 exports.eejsBlock_timesliderStyles = function (hook_name, args, cb) {
   args.content = `${args.content}<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`;
+  return cb();
+};
+
+exports.padInitToolbar = function (hook_name, args, cb) {
+  const toolbar = args.toolbar;
+  const sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
+  const fontSize = toolbar.selectButton({
+      command: 'fontSize',
+      class: 'size-selection',
+      selectId: 'font-size'
+  });
+  fontSize.addOption('dummy', 'Font Size', {'data-l10n-id': 'ep_font_size.size'});
+  sizes.forEach(function (size, value) {
+    fontSize.addOption(value, size);
+  });
+
+  toolbar.registerButton('fontSize', fontSize);
   return cb();
 };

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -10,7 +10,7 @@ var sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19
 
 // Bind the event handler to the toolbar buttons
 var postAceInit = function (hook, context) {
-  const hs = $('.size-selection');
+  const hs = $('.size-selection, #font-size');
   hs.on('change', function () {
     const value = $(this).val();
     const intValue = parseInt(value, 10);
@@ -23,6 +23,7 @@ var postAceInit = function (hook, context) {
   });
   $('.font_size').hover(() => {
     $('.submenu > .size-selection').attr('size', 6);
+    $('.submenu > #font-size').attr('size', 6);
   });
   $('.font-size-icon').click(() => {
     $('#font-size').toggle();
@@ -93,8 +94,17 @@ function aceEditorCSS() {
   return cssFiles;
 }
 
+function postToolbarInit (hook_name, context) {
+  const editbar = context.toolbar;
+
+  editbar.registerCommand('fontSize', function (buttonName, toolbar, item) {
+    $('#font-size').toggle();
+  });
+};
+
 
 // Export all hooks
+exports.postToolbarInit = postToolbarInit;
 exports.aceInitialized = aceInitialized;
 exports.postAceInit = postAceInit;
 exports.aceAttribsToClasses = aceAttribsToClasses;

--- a/static/tests/frontend/specs/l10n.js
+++ b/static/tests/frontend/specs/l10n.js
@@ -1,0 +1,51 @@
+describe("Select font-size dropdown localization", function(){
+    //create a new pad with comment before each test run
+    beforeEach(function(cb){
+      helper.newPad(function() {
+        changeEtherpadLanguageTo('fr', cb);
+      });
+      this.timeout(60000);
+    });
+
+    // ensure we go back to English to avoid breaking other tests:
+    after(function(cb){
+      changeEtherpadLanguageTo('en', cb);
+    });
+
+    it("Localizes dropdown when Etherpad language is changed", function(done) {
+      const optionTranslations = {
+        "ep_font_size.size": "Taille"
+      }
+      let chrome$ = helper.padChrome$;
+      const $option = chrome$("#editbar").find('#font-size').find('option').first();
+
+      expect($option.text()).to.be(optionTranslations[$option.attr('data-l10n-id')]);
+
+      return done();
+    });
+
+    const changeEtherpadLanguageTo = function(lang, callback) {
+      const boldTitles = {
+        'en' : 'Bold (Ctrl+B)',
+        'fr' : 'Gras (Ctrl+B)'
+      };
+      const chrome$ = helper.padChrome$;
+
+      //click on the settings button to make settings visible
+      const $settingsButton = chrome$(".buttonicon-settings");
+      $settingsButton.click();
+
+      //select the language
+      const $language = chrome$("#languagemenu");
+      $language.val(lang);
+      $language.change();
+
+      // hide settings again
+      $settingsButton.click();
+
+      helper.waitFor(function() {
+        return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
+      })
+      .done(callback);
+    }
+  });


### PR DESCRIPTION
Make possible to add font size selector from settings.json, if not in settings will fallback to default template. Also added translation test.