### PR TITLE
Numerous fixes and cleanups

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -4,25 +4,55 @@
 name: Node.js Package
 
 on:
-#trigger on every commit to the main branch
+  pull_request:
   push:
     branches:
       - main
       - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
+      # Clone ether/etherpad-lite to ../etherpad-lite so that ep_etherpad-lite
+      # can be "installed" in this plugin's node_modules. The checkout v2 action
+      # doesn't support cloning outside of $GITHUB_WORKSPACE (see
+      # https://github.com/actions/checkout/issues/197), so the repo is first
+      # cloned to etherpad-lite then moved to ../etherpad-lite. To avoid
+      # conflicts with this plugin's clone, etherpad-lite must be cloned and
+      # moved out before this plugin's repo is cloned to $GITHUB_WORKSPACE.
+      - uses: actions/checkout@v2
+        with:
+          repository: ether/etherpad-lite
+          path: etherpad-lite
+      - run: mv etherpad-lite ..
+      # etherpad-lite has been moved outside of $GITHUB_WORKSPACE, so it is now
+      # safe to clone this plugin's repo to $GITHUB_WORKSPACE.
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      # All of ep_etherpad-lite's devDependencies are installed because the
+      # plugin might do `require('ep_etherpad-lite/node_modules/${devDep}')`.
+      # Eventually it would be nice to create an ESLint plugin that prohibits
+      # Etherpad plugins from piggybacking off of ep_etherpad-lite's
+      # devDependencies. If we had that, we could change this line to only
+      # install production dependencies.
+      - run: cd ../etherpad-lite/src && npm ci
       - run: npm ci
+      # This runs some sanity checks and creates a symlink at
+      # node_modules/ep_etherpad-lite that points to ../../etherpad-lite/src.
+      # This step must be done after `npm ci` installs the plugin's dependencies
+      # because npm "helpfully" cleans up such symlinks. :( Installing
+      # ep_etherpad-lite in the plugin's node_modules prevents lint errors and
+      # unit test failures if the plugin does `require('ep_etherpad-lite/foo')`.
+      - run: npm install --no-save ep_etherpad-lite@file:../etherpad-lite/src
       - run: npm test
+      - run: npm run lint
 
   publish-npm:
-    needs: build
+    if: github.event_name == 'push'
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/ep.json
+++ b/ep.json
@@ -15,7 +15,6 @@
         "padInitToolbar": "ep_font_size/index",
         "eejsBlock_editbarMenuLeft": "ep_font_size/index",
         "collectContentPre": "ep_font_size/static/js/shared",
-        "collectContentPost": "ep_font_size/static/js/shared",
         "exportHtmlAdditionalTagsWithData": "ep_font_size/exportHTML",
         "stylesForExport": "ep_font_size/exportHTML",
         "getLineHTMLForExport": "ep_font_size/exportHTML",

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -3,14 +3,11 @@
 const eejs = require('ep_etherpad-lite/node/eejs/');
 
 // Add the props to be supported in export
-exports.exportHtmlAdditionalTagsWithData = async (hookName, pad) => findAllsizeUsedOn(pad).map((name) => ['font-size', name]);
-
-// Iterate over pad attributes to find only the size ones
-function findAllsizeUsedOn(pad) {
-  const sizesUsed = [];
-  pad.pool.eachAttrib((key, value) => { if (key === 'font-size') sizesUsed.push(value); });
-  return sizesUsed;
-}
+exports.exportHtmlAdditionalTagsWithData = async (hookName, pad) => {
+  const ret = [];
+  pad.pool.eachAttrib((k, v) => { if (k === 'font-size') ret.push([k, v]); });
+  return ret;
+};
 
 // Include CSS for HTML export
 exports.stylesForExport = async (hookName, padId) => eejs.require('ep_font_size/static/css/size.css');

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const eejs = require('ep_etherpad-lite/node/eejs/');
 
 // Add the props to be supported in export

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -10,10 +10,11 @@ exports.exportHtmlAdditionalTagsWithData = async (hookName, pad) => {
 };
 
 // Include CSS for HTML export
-exports.stylesForExport = async (hookName, padId) => eejs.require('ep_font_size/static/css/size.css');
+exports.stylesForExport =
+    async (hookName, padId) => eejs.require('ep_font_size/static/css/size.css');
 
 exports.getLineHTMLForExport = async (hookName, context) => {
   // Replace data-size="foo" with class="font-size:x".
-  context.lineContent =
-      context.lineContent.replace(/data-font-size=["|']([0-9a-zA-Z]+)["|']/gi, 'class="font-size:$1"');
+  context.lineContent = context.lineContent.replace(
+      /data-font-size=["|']([0-9a-zA-Z]+)["|']/gi, 'class="font-size:$1"');
 };

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -1,7 +1,4 @@
-const _ = require('ep_etherpad-lite/static/js/underscore');
 const eejs = require('ep_etherpad-lite/node/eejs/');
-
-const sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
 
 // Add the props to be supported in export
 exports.exportHtmlAdditionalTagsWithData = async (hookName, pad) => findAllsizeUsedOn(pad).map((name) => ['font-size', name]);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const eejs = require('ep_etherpad-lite/node/eejs/');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 const shared = require('./static/js/shared');

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.eejsBlock_dd_format = function (hookName, args, cb) {
 };
 
 exports.eejsBlock_timesliderStyles = function (hookName, args, cb) {
-  args.content = `${args.content}<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`;
+  args.content += `<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`;
   return cb();
 };
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const eejs = require('ep_etherpad-lite/node/eejs/');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 const shared = require('./static/js/shared');
 
-exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
+exports.eejsBlock_editbarMenuLeft = function (hookName, args, cb) {
   if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1) {
     return cb();
   }
@@ -12,17 +12,17 @@ exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
   return cb();
 };
 
-exports.eejsBlock_dd_format = function (hook_name, args, cb) {
+exports.eejsBlock_dd_format = function (hookName, args, cb) {
   args.content += eejs.require('ep_font_size/templates/fileMenu.ejs');
   return cb();
 };
 
-exports.eejsBlock_timesliderStyles = function (hook_name, args, cb) {
+exports.eejsBlock_timesliderStyles = function (hookName, args, cb) {
   args.content = `${args.content}<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`;
   return cb();
 };
 
-exports.padInitToolbar = function (hook_name, args, cb) {
+exports.padInitToolbar = function (hookName, args, cb) {
   const toolbar = args.toolbar;
   const fontSize = toolbar.selectButton({
     command: 'fontSize',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const eejs = require('ep_etherpad-lite/node/eejs/');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
+const shared = require('./static/js/shared');
 
 exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
   if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1 ) {
@@ -21,14 +22,13 @@ exports.eejsBlock_timesliderStyles = function (hook_name, args, cb) {
 
 exports.padInitToolbar = function (hook_name, args, cb) {
   const toolbar = args.toolbar;
-  const sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
   const fontSize = toolbar.selectButton({
       command: 'fontSize',
       class: 'size-selection',
       selectId: 'font-size'
   });
   fontSize.addOption('dummy', 'Font Size', {'data-l10n-id': 'ep_font_size.size'});
-  sizes.forEach(function (size, value) {
+  shared.sizes.forEach(function (size, value) {
     fontSize.addOption(value, size);
   });
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const settings = require('ep_etherpad-lite/node/utils/Settings');
 const shared = require('./static/js/shared');
 
 exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
-  if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1 ) {
+  if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1) {
     return cb();
   }
   args.content += eejs.require('ep_font_size/templates/editbarButtons.ejs');
@@ -23,12 +23,12 @@ exports.eejsBlock_timesliderStyles = function (hook_name, args, cb) {
 exports.padInitToolbar = function (hook_name, args, cb) {
   const toolbar = args.toolbar;
   const fontSize = toolbar.selectButton({
-      command: 'fontSize',
-      class: 'size-selection',
-      selectId: 'font-size'
+    command: 'fontSize',
+    class: 'size-selection',
+    selectId: 'font-size',
   });
   fontSize.addOption('dummy', 'Font Size', {'data-l10n-id': 'ep_font_size.size'});
-  shared.sizes.forEach(function (size, value) {
+  shared.sizes.forEach((size, value) => {
     fontSize.addOption(value, size);
   });
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const eejs = require('ep_etherpad-lite/node/eejs/');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 const shared = require('./static/js/shared');
 
-exports.eejsBlock_editbarMenuLeft = function (hookName, args, cb) {
+exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
   if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1) {
     return cb();
   }
@@ -12,17 +12,17 @@ exports.eejsBlock_editbarMenuLeft = function (hookName, args, cb) {
   return cb();
 };
 
-exports.eejsBlock_dd_format = function (hookName, args, cb) {
+exports.eejsBlock_dd_format = (hookName, args, cb) => {
   args.content += eejs.require('ep_font_size/templates/fileMenu.ejs');
   return cb();
 };
 
-exports.eejsBlock_timesliderStyles = function (hookName, args, cb) {
+exports.eejsBlock_timesliderStyles = (hookName, args, cb) => {
   args.content += `<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`;
   return cb();
 };
 
-exports.padInitToolbar = function (hookName, args, cb) {
+exports.padInitToolbar = (hookName, args, cb) => {
   const toolbar = args.toolbar;
   const fontSize = toolbar.selectButton({
     command: 'fontSize',

--- a/package-lock.json
+++ b/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "eslint-config-etherpad": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-etherpad/-/eslint-config-etherpad-1.0.8.tgz",
-      "integrity": "sha512-odyWuleMjuzxvrkc2hmTla8gmryRBJC9toxt36tabpv2vLxysgqjktGrUa9Go8m3Xeiiyy33ic07X0PLIvYF6Q==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/eslint-config-etherpad/-/eslint-config-etherpad-1.0.13.tgz",
+      "integrity": "sha512-wuykfSQyQj7EDN4Ok2SR5l59QOtozeANbIfew9MloUVh0P80+PIY45pXNblMrLEa9EUxYvKQQywzUWyQxHiweQ==",
       "dev": true
     },
     "eslint-plugin-es": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "eslint": "^7.14.0",
-    "eslint-config-etherpad": "^1.0.8",
+    "eslint-config-etherpad": "^1.0.13",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prefer-arrow": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {},
   "engines": {
-    "node": "*"
+    "node": ">=10.13.0"
   },
   "repository": {
     "type": "git",
@@ -35,6 +35,9 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prefer-arrow": "^1.2.2",
     "eslint-plugin-promise": "^4.2.1"
+  },
+  "peerDependencies": {
+    "ep_etherpad-lite": "*"
   },
   "eslintConfig": {
     "root": true,

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,11 +1,8 @@
-var _, $, jQuery;
-
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var cssFiles = ['ep_font_size/static/css/size.css'];
 
 // All our sizes are block elements, so we just return them.
-// var sizes = ['black', 'red', 'green', 'blue', 'yellow', 'orange'];
 var sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
 
 // Bind the event handler to the toolbar buttons
@@ -45,7 +42,6 @@ function aceAttribsToClasses(hook, context) {
 // Here we convert the class size:red into a tag
 exports.aceCreateDomLine = function (name, context) {
   const cls = context.cls;
-  const domline = context.domline;
   const sizesType = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls);
 
   let tagIndex;
@@ -53,7 +49,6 @@ exports.aceCreateDomLine = function (name, context) {
 
 
   if (tagIndex !== undefined && tagIndex >= 0) {
-    const tag = sizes[tagIndex];
     const modifier = {
       extraOpenTags: '',
       extraCloseTags: '',

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,4 +1,3 @@
-var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 const shared = require('./shared');
 var cssFiles = ['ep_font_size/static/css/size.css'];

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -25,7 +25,6 @@ exports.postAceInit = (hookName, context) => {
   });
 };
 
-// Our sizes attribute will result in a size:red... _yellow class
 exports.aceAttribsToClasses = (hookName, context) => {
   if (context.key.indexOf('font-size:') !== -1) {
     const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.key);
@@ -36,8 +35,6 @@ exports.aceAttribsToClasses = (hookName, context) => {
   }
 };
 
-
-// Here we convert the class size:red into a tag
 exports.aceCreateDomLine = (hookName, context) => {
   const cls = context.cls;
   const sizesType = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -37,21 +37,15 @@ exports.aceAttribsToClasses = (hookName, context) => {
 
 exports.aceCreateDomLine = (hookName, context) => {
   const cls = context.cls;
-  const sizesType = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls);
-
-  let tagIndex;
-  if (sizesType) tagIndex = _.indexOf(shared.sizes, sizesType[1]);
-
-
-  if (tagIndex !== undefined && tagIndex >= 0) {
-    const modifier = {
-      extraOpenTags: '',
-      extraCloseTags: '',
-      cls,
-    };
-    return [modifier];
-  }
-  return [];
+  const [, sizesType] = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls) || [];
+  if (sizesType == null) return [];
+  const tagIndex = _.indexOf(shared.sizes, sizesType);
+  if (tagIndex < 0) return [];
+  return [{
+    extraOpenTags: '',
+    extraCloseTags: '',
+    cls,
+  }];
 };
 
 exports.aceInitialized = (hookName, context) => {
@@ -68,9 +62,7 @@ exports.aceInitialized = (hookName, context) => {
 exports.aceEditorCSS = () => ['ep_font_size/static/css/size.css'];
 
 exports.postToolbarInit = (hookName, context) => {
-  const editbar = context.toolbar;
-
-  editbar.registerCommand('fontSize', (buttonName, toolbar, item) => {
+  context.toolbar.registerCommand('fontSize', (buttonName, toolbar, item) => {
     $('#font-size').toggle();
   });
 };

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -4,7 +4,7 @@ var cssFiles = ['ep_font_size/static/css/size.css'];
 
 // Bind the event handler to the toolbar buttons
 exports.postAceInit = function (hook, context) {
-  const hs = $('.size-selection, #font-size');
+  const hs = $('#font-size select.size-selection');
   hs.on('change', function () {
     const value = $(this).val();
     const intValue = parseInt(value, 10);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5,7 +5,7 @@ const shared = require('./shared');
 var cssFiles = ['ep_font_size/static/css/size.css'];
 
 // Bind the event handler to the toolbar buttons
-exports.postAceInit = function (hook, context) {
+exports.postAceInit = function (hookName, context) {
   const hs = $('#font-size select.size-selection');
   hs.on('change', function () {
     const value = $(this).val();
@@ -27,7 +27,7 @@ exports.postAceInit = function (hook, context) {
 };
 
 // Our sizes attribute will result in a size:red... _yellow class
-exports.aceAttribsToClasses = function (hook, context) {
+exports.aceAttribsToClasses = function (hookName, context) {
   if (context.key.indexOf('font-size:') !== -1) {
     const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.key);
     return [`font-size:${size[1]}`];
@@ -39,7 +39,7 @@ exports.aceAttribsToClasses = function (hook, context) {
 
 
 // Here we convert the class size:red into a tag
-exports.aceCreateDomLine = function (name, context) {
+exports.aceCreateDomLine = function (hookName, context) {
   const cls = context.cls;
   const sizesType = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls);
 
@@ -79,7 +79,7 @@ function doInsertsizes(level) {
 
 
 // Once ace is initialized, we set ace_doInsertsizes and bind it to the context
-exports.aceInitialized = function (hook, context) {
+exports.aceInitialized = function (hookName, context) {
   const editorInfo = context.editorInfo;
   editorInfo.ace_doInsertsizes = _(doInsertsizes).bind(context);
 };
@@ -88,7 +88,7 @@ exports.aceEditorCSS = function () {
   return cssFiles;
 };
 
-exports.postToolbarInit = function (hook_name, context) {
+exports.postToolbarInit = function (hookName, context) {
   const editbar = context.toolbar;
 
   editbar.registerCommand('fontSize', (buttonName, toolbar, item) => {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -6,7 +6,7 @@ var cssFiles = ['ep_font_size/static/css/size.css'];
 var sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
 
 // Bind the event handler to the toolbar buttons
-var postAceInit = function (hook, context) {
+exports.postAceInit = function (hook, context) {
   const hs = $('.size-selection, #font-size');
   hs.on('change', function () {
     const value = $(this).val();
@@ -28,7 +28,7 @@ var postAceInit = function (hook, context) {
 };
 
 // Our sizes attribute will result in a size:red... _yellow class
-function aceAttribsToClasses(hook, context) {
+exports.aceAttribsToClasses = function (hook, context) {
   if (context.key.indexOf('font-size:') !== -1) {
     const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.key);
     return [`font-size:${size[1]}`];
@@ -36,7 +36,7 @@ function aceAttribsToClasses(hook, context) {
   if (context.key == 'font-size') {
     return [`font-size:${context.value}`];
   }
-}
+};
 
 
 // Here we convert the class size:red into a tag
@@ -80,27 +80,19 @@ function doInsertsizes(level) {
 
 
 // Once ace is initialized, we set ace_doInsertsizes and bind it to the context
-function aceInitialized(hook, context) {
+exports.aceInitialized = function (hook, context) {
   const editorInfo = context.editorInfo;
   editorInfo.ace_doInsertsizes = _(doInsertsizes).bind(context);
-}
+};
 
-function aceEditorCSS() {
+exports.aceEditorCSS = function () {
   return cssFiles;
-}
+};
 
-function postToolbarInit (hook_name, context) {
+exports.postToolbarInit = function (hook_name, context) {
   const editbar = context.toolbar;
 
   editbar.registerCommand('fontSize', function (buttonName, toolbar, item) {
     $('#font-size').toggle();
   });
 };
-
-
-// Export all hooks
-exports.postToolbarInit = postToolbarInit;
-exports.aceInitialized = aceInitialized;
-exports.postAceInit = postAceInit;
-exports.aceAttribsToClasses = aceAttribsToClasses;
-exports.aceEditorCSS = aceEditorCSS;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -2,7 +2,6 @@
 
 var _ = require('ep_etherpad-lite/static/js/underscore');
 const shared = require('./shared');
-var cssFiles = ['ep_font_size/static/css/size.css'];
 
 // Bind the event handler to the toolbar buttons
 exports.postAceInit = function (hookName, context) {
@@ -58,35 +57,18 @@ exports.aceCreateDomLine = function (hookName, context) {
   return [];
 };
 
-
-// Find out which lines are selected and assign them the size attribute.
-// Passing a level >= 0 will set a sizes on the selected lines, level < 0
-// will remove it
-function doInsertsizes(level) {
-  const rep = this.rep;
-  const documentAttributeManager = this.documentAttributeManager;
-  if (!(rep.selStart && rep.selEnd) || (level >= 0 && shared.sizes[level] === undefined)) {
-    return;
-  }
-
-  let new_size = ['font-size', ''];
-  if (level >= 0) {
-    new_size = ['font-size', shared.sizes[level]];
-  }
-
-  documentAttributeManager.setAttributesOnRange(rep.selStart, rep.selEnd, [new_size]);
-}
-
-
-// Once ace is initialized, we set ace_doInsertsizes and bind it to the context
-exports.aceInitialized = function (hookName, context) {
-  const editorInfo = context.editorInfo;
-  editorInfo.ace_doInsertsizes = _(doInsertsizes).bind(context);
+exports.aceInitialized = (hookName, context) => {
+  // Passing a level >= 0 will set a sizes on the selected lines, level < 0 will remove it
+  context.editorInfo.ace_doInsertsizes = (level) => {
+    const {rep, documentAttributeManager} = context;
+    if (!(rep.selStart && rep.selEnd)) return;
+    if (level >= 0 && shared.sizes[level] === undefined) return;
+    const newSize = ['font-size', level >= 0 ? shared.sizes[level] : ''];
+    documentAttributeManager.setAttributesOnRange(rep.selStart, rep.selEnd, [newSize]);
+  };
 };
 
-exports.aceEditorCSS = function () {
-  return cssFiles;
-};
+exports.aceEditorCSS = () => ['ep_font_size/static/css/size.css'];
 
 exports.postToolbarInit = function (hookName, context) {
   const editbar = context.toolbar;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _ = require('ep_etherpad-lite/static/js/underscore');
+const _ = require('ep_etherpad-lite/static/js/underscore');
 const shared = require('./shared');
 
 // Bind the event handler to the toolbar buttons
-exports.postAceInit = function (hookName, context) {
+exports.postAceInit = (hookName, context) => {
   const hs = $('#font-size select.size-selection');
   hs.on('change', function () {
     const value = $(this).val();
@@ -26,19 +26,19 @@ exports.postAceInit = function (hookName, context) {
 };
 
 // Our sizes attribute will result in a size:red... _yellow class
-exports.aceAttribsToClasses = function (hookName, context) {
+exports.aceAttribsToClasses = (hookName, context) => {
   if (context.key.indexOf('font-size:') !== -1) {
     const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.key);
     return [`font-size:${size[1]}`];
   }
-  if (context.key == 'font-size') {
+  if (context.key === 'font-size') {
     return [`font-size:${context.value}`];
   }
 };
 
 
 // Here we convert the class size:red into a tag
-exports.aceCreateDomLine = function (hookName, context) {
+exports.aceCreateDomLine = (hookName, context) => {
   const cls = context.cls;
   const sizesType = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls);
 
@@ -70,7 +70,7 @@ exports.aceInitialized = (hookName, context) => {
 
 exports.aceEditorCSS = () => ['ep_font_size/static/css/size.css'];
 
-exports.postToolbarInit = function (hookName, context) {
+exports.postToolbarInit = (hookName, context) => {
   const editbar = context.toolbar;
 
   editbar.registerCommand('fontSize', (buttonName, toolbar, item) => {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('ep_etherpad-lite/static/js/underscore');
 const shared = require('./shared');
 var cssFiles = ['ep_font_size/static/css/size.css'];

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -89,7 +89,7 @@ exports.aceEditorCSS = function () {
 exports.postToolbarInit = function (hook_name, context) {
   const editbar = context.toolbar;
 
-  editbar.registerCommand('fontSize', function (buttonName, toolbar, item) {
+  editbar.registerCommand('fontSize', (buttonName, toolbar, item) => {
     $('#font-size').toggle();
   });
 };

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,9 +1,7 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
+const shared = require('./shared');
 var cssFiles = ['ep_font_size/static/css/size.css'];
-
-// All our sizes are block elements, so we just return them.
-var sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
 
 // Bind the event handler to the toolbar buttons
 exports.postAceInit = function (hook, context) {
@@ -45,7 +43,7 @@ exports.aceCreateDomLine = function (name, context) {
   const sizesType = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls);
 
   let tagIndex;
-  if (sizesType) tagIndex = _.indexOf(sizes, sizesType[1]);
+  if (sizesType) tagIndex = _.indexOf(shared.sizes, sizesType[1]);
 
 
   if (tagIndex !== undefined && tagIndex >= 0) {
@@ -66,13 +64,13 @@ exports.aceCreateDomLine = function (name, context) {
 function doInsertsizes(level) {
   const rep = this.rep;
   const documentAttributeManager = this.documentAttributeManager;
-  if (!(rep.selStart && rep.selEnd) || (level >= 0 && sizes[level] === undefined)) {
+  if (!(rep.selStart && rep.selEnd) || (level >= 0 && shared.sizes[level] === undefined)) {
     return;
   }
 
   let new_size = ['font-size', ''];
   if (level >= 0) {
-    new_size = ['font-size', sizes[level]];
+    new_size = ['font-size', shared.sizes[level]];
   }
 
   documentAttributeManager.setAttributesOnRange(rep.selStart, rep.selEnd, [new_size]);

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,8 +1,6 @@
-var collectContentPre = function (hook, context) {
+exports.collectContentPre = function (hook, context) {
   const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.cls);
   if (size && size[1]) {
     context.cc.doAttrib(context.state, `font-size:${size[1]}`);
   }
 };
-
-exports.collectContentPre = collectContentPre;

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,3 +1,6 @@
+// Starts at b, ends just before e, skipping s each time.
+const range = (b, e, s = 1) => [...Array(Math.ceil((e - b) / s)).keys()].map((x) => (x * s) + b);
+
 exports.collectContentPre = function (hook, context) {
   const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.cls);
   if (size && size[1]) {
@@ -5,28 +8,8 @@ exports.collectContentPre = function (hook, context) {
   }
 };
 
-exports.sizes = [
-  '8',
-  '9',
-  '10',
-  '11',
-  '12',
-  '13',
-  '14',
-  '15',
-  '16',
-  '17',
-  '18',
-  '19',
-  '20',
-  '22',
-  '24',
-  '26',
-  '28',
-  '30',
-  '35',
-  '40',
-  '45',
-  '50',
-  '60',
-];
+exports.sizes = []
+    .concat(range(8, 20))
+    .concat(range(20, 30, 2))
+    .concat(range(30, 50, 5))
+    .concat(range(50, 70, 10));

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -3,7 +3,7 @@
 // Starts at b, ends just before e, skipping s each time.
 const range = (b, e, s = 1) => [...Array(Math.ceil((e - b) / s)).keys()].map((x) => (x * s) + b);
 
-exports.collectContentPre = function (hook, context) {
+exports.collectContentPre = function (hookName, context) {
   const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.cls);
   if (size && size[1]) {
     context.cc.doAttrib(context.state, `font-size:${size[1]}`);

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -3,7 +3,7 @@
 // Starts at b, ends just before e, skipping s each time.
 const range = (b, e, s = 1) => [...Array(Math.ceil((e - b) / s)).keys()].map((x) => (x * s) + b);
 
-exports.collectContentPre = function (hookName, context) {
+exports.collectContentPre = (hookName, context) => {
   const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.cls);
   if (size && size[1]) {
     context.cc.doAttrib(context.state, `font-size:${size[1]}`);

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Starts at b, ends just before e, skipping s each time.
 const range = (b, e, s = 1) => [...Array(Math.ceil((e - b) / s)).keys()].map((x) => (x * s) + b);
 

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,7 +1,3 @@
-var _ = require('ep_etherpad-lite/static/js/underscore');
-
-var sizes = ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '22', '24', '26', '28', '30', '35', '40', '45', '50', '60'];
-
 var collectContentPre = function (hook, context) {
   const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.cls);
   if (size && size[1]) {
@@ -9,18 +5,4 @@ var collectContentPre = function (hook, context) {
   }
 };
 
-var collectContentPost = function (hook, context) {
-/*
-  var tname = context.tname;
-  var state = context.state;
-  var lineAttributes = state.lineAttributes
-  var tagIndex = _.indexOf(sizes, tname);
-
-  if(tagIndex >= 0){
-    delete lineAttributes['size'];
-  }
-*/
-};
-
 exports.collectContentPre = collectContentPre;
-exports.collectContentPost = collectContentPost;

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -4,3 +4,29 @@ exports.collectContentPre = function (hook, context) {
     context.cc.doAttrib(context.state, `font-size:${size[1]}`);
   }
 };
+
+exports.sizes = [
+  '8',
+  '9',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+  '20',
+  '22',
+  '24',
+  '26',
+  '28',
+  '30',
+  '35',
+  '40',
+  '45',
+  '50',
+  '60',
+];

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const appUrl = 'http://localhost:9001';
 const apiVersion = 1;
 

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -24,10 +24,8 @@ describe('ep_font_size - export size styles to HTML', function () {
   });
 
   context('when pad text has one size', function () {
-    before(function () {
-      html = function () {
-        return buildHTML(textWithSize('8'));
-      };
+    before(async function () {
+      html = () => buildHTML(textWithSize('8'));
     });
 
     it('returns ok', function (done) {
@@ -54,10 +52,8 @@ describe('ep_font_size - export size styles to HTML', function () {
   });
 
   context('when pad text has two sizes in a single line', function () {
-    before(function () {
-      html = function () {
-        return buildHTML(textWithSize('8') + textWithSize('9'));
-      };
+    before(async function () {
+      html = () => buildHTML(textWithSize('8') + textWithSize('9'));
     });
 
     it('returns HTML with two size spans', function (done) {
@@ -80,10 +76,8 @@ describe('ep_font_size - export size styles to HTML', function () {
   });
 
   context('when pad text has no sizes', function () {
-    before(function () {
-      html = function () {
-        return buildHTML('empty pad');
-      };
+    before(async function () {
+      html = () => buildHTML('empty pad');
     });
 
     it('returns HTML with no size', function (done) {
@@ -104,10 +98,8 @@ describe('ep_font_size - export size styles to HTML', function () {
   });
 
   context('when pad text has size inside strong', function () {
-    before(function () {
-      html = function () {
-        return buildHTML(`<strong>${textWithSize('8', 'this is size 8 and bold')}</strong>`);
-      };
+    before(async function () {
+      html = () => buildHTML(`<strong>${textWithSize('8', 'this is size 8 and bold')}</strong>`);
     });
 
     // Etherpad exports tags using the order they are defined on the array (bold is always inside
@@ -130,10 +122,8 @@ describe('ep_font_size - export size styles to HTML', function () {
   });
 
   context('when pad text has strong inside size', function () {
-    before(function () {
-      html = function () {
-        return buildHTML(textWithSize('8', '<strong>this is size 8 and bold</strong>'));
-      };
+    before(async function () {
+      html = () => buildHTML(textWithSize('8', '<strong>this is size 8 and bold</strong>'));
     });
 
     // Etherpad exports tags using the order they are defined on the array (bold is always inside
@@ -156,10 +146,8 @@ describe('ep_font_size - export size styles to HTML', function () {
   });
 
   context('when pad text has part with size and part without it', function () {
-    before(function () {
-      html = function () {
-        return buildHTML(`no size here ${textWithSize('8')}`);
-      };
+    before(async function () {
+      html = () => buildHTML(`no size here ${textWithSize('8')}`);
     });
 
     it('returns HTML with part with size and part without it', function (done) {
@@ -180,9 +168,9 @@ describe('ep_font_size - export size styles to HTML', function () {
 });
 
 // Loads the APIKEY.txt content into a string, and returns it.
-const getApiKey = function () {
-  const etherpad_root = '/../../../../../../ep_etherpad-lite/../..';
-  const filePath = path.join(__dirname, `${etherpad_root}/APIKEY.txt`);
+const getApiKey = () => {
+  const etherpadRoot = '/../../../../../../ep_etherpad-lite/../..';
+  const filePath = path.join(__dirname, `${etherpadRoot}/APIKEY.txt`);
   const apiKey = fs.readFileSync(filePath, {encoding: 'utf-8'});
   return apiKey.replace(/\n$/, '');
 };
@@ -190,7 +178,7 @@ const getApiKey = function () {
 const apiKey = getApiKey();
 
 // Creates a pad and returns the pad id. Calls the callback when finished.
-var createPad = function (padID, callback) {
+const createPad = (padID, callback) => {
   api.get(`/api/${apiVersion}/createPad?apikey=${apiKey}&padID=${padID}`)
       .end((err, res) => {
         if (err || (res.body.code !== 0)) callback(new Error('Unable to create new Pad'));
@@ -199,7 +187,7 @@ var createPad = function (padID, callback) {
       });
 };
 
-var setHTML = function (padID, html, callback) {
+const setHTML = (padID, html, callback) => {
   api.get(`/api/${apiVersion}/setHTML?apikey=${apiKey}&padID=${padID}&html=${html}`)
       .end((err, res) => {
         if (err || (res.body.code !== 0)) callback(new Error('Unable to set pad HTML'));
@@ -208,35 +196,32 @@ var setHTML = function (padID, html, callback) {
       });
 };
 
-var getHTMLEndPointFor = function (padID, callback) {
-  return `/api/${apiVersion}/getHTML?apikey=${apiKey}&padID=${padID}`;
-};
+const getHTMLEndPointFor =
+    (padID, callback) => `/api/${apiVersion}/getHTML?apikey=${apiKey}&padID=${padID}`;
 
-const codeToBe = function (expectedCode, res) {
+const codeToBe = (expectedCode, res) => {
   if (res.body.code !== expectedCode) {
     throw new Error(`Code should be ${expectedCode}, was ${res.body.code}`);
   }
 };
 
-var codeToBe0 = function (res) { codeToBe(0, res); };
+const codeToBe0 = (res) => { codeToBe(0, res); };
 
-var buildHTML = function (body) {
-  return `<html><body>${body}</body></html>`;
-};
+const buildHTML = (body) => `<html><body>${body}</body></html>`;
 
-var textWithSize = function (size, text) {
+const textWithSize = (size, text) => {
   if (!text) text = `this is ${size}`;
 
   return `<span class='font-size:${size}'>${text}</span>`;
 };
 
-var regexWithSize = function (size, text) {
+const regexWithSize = (size, text) => {
   if (!text) text = `this is ${size}`;
 
-  const regex = `<span .*class=['|"].*font-size:${size}.*['|"].*>${text}<\/span>`;
+  const regex = `<span .*class=['|"].*font-size:${size}.*['|"].*>${text}</span>`;
   // bug fix: if no other plugin on the Etherpad instance returns a value on getLineHTMLForExport()
   // hook, data-size=(...) won't be replaced by class=size:(...), so we need a fallback regex
-  const fallbackRegex = `<span .*data-font-size=['|"]${size}['|"].*>${text}<\/span>`;
+  const fallbackRegex = `<span .*data-font-size=['|"]${size}['|"].*>${text}</span>`;
 
   return `${regex} || ${fallbackRegex}`;
 };

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -44,7 +44,10 @@ describe('ep_font_size - export size styles to HTML', function () {
             const expectedsizes = new RegExp(expectedRegex);
             const html = res.body.data.html;
             const foundsize = html.match(expectedsizes);
-            if (!foundsize) throw new Error(`size not exported. Regex used: ${expectedRegex}, html exported: ${html}`);
+            if (!foundsize) {
+              throw new Error(
+                  `size not exported. Regex used: ${expectedRegex}, html exported: ${html}`);
+            }
           })
           .end(done);
     });
@@ -67,7 +70,10 @@ describe('ep_font_size - export size styles to HTML', function () {
 
             const html = res.body.data.html;
             const foundsize = html.match(expectedsizes);
-            if (!foundsize) throw new Error(`size not exported. Regex used: ${expectedRegex}, html exported: ${html}`);
+            if (!foundsize) {
+              throw new Error(
+                  `size not exported. Regex used: ${expectedRegex}, html exported: ${html}`);
+            }
           })
           .end(done);
     });
@@ -88,7 +94,10 @@ describe('ep_font_size - export size styles to HTML', function () {
 
             const html = res.body.data.html;
             const foundsize = html.match(nosize);
-            if (!foundsize) throw new Error(`size exported, should not have any. Regex used: ${expectedRegex}, html exported: ${html}`);
+            if (!foundsize) {
+              throw new Error('size exported, should not have any. ' +
+                              `Regex used: ${expectedRegex}, html exported: ${html}`);
+            }
           })
           .end(done);
     });
@@ -101,7 +110,8 @@ describe('ep_font_size - export size styles to HTML', function () {
       };
     });
 
-    // Etherpad exports tags using the order they are defined on the array (bold is always inside size)
+    // Etherpad exports tags using the order they are defined on the array (bold is always inside
+    // size)
     it('returns HTML with strong and size, in any order', function (done) {
       api.get(getHTMLEndPointFor(padID))
           .expect((res) => {
@@ -126,7 +136,8 @@ describe('ep_font_size - export size styles to HTML', function () {
       };
     });
 
-    // Etherpad exports tags using the order they are defined on the array (bold is always inside size)
+    // Etherpad exports tags using the order they are defined on the array (bold is always inside
+    // size)
     it('returns HTML with strong and size, in any order', function (done) {
       api.get(getHTMLEndPointFor(padID))
           .expect((res) => {
@@ -158,7 +169,10 @@ describe('ep_font_size - export size styles to HTML', function () {
             const expectedsizes = new RegExp(expectedRegex);
             const html = res.body.data.html;
             const foundsize = html.match(expectedsizes);
-            if (!foundsize) throw new Error(`size not exported. Regex used: ${expectedRegex}, html exported: ${html}`);
+            if (!foundsize) {
+              throw new Error(
+                  `size not exported. Regex used: ${expectedRegex}, html exported: ${html}`);
+            }
           })
           .end(done);
     });
@@ -220,8 +234,8 @@ var regexWithSize = function (size, text) {
   if (!text) text = `this is ${size}`;
 
   const regex = `<span .*class=['|"].*font-size:${size}.*['|"].*>${text}<\/span>`;
-  // bug fix: if no other plugin on the Etherpad instance returns a value on getLineHTMLForExport() hook,
-  // data-size=(...) won't be replaced by class=size:(...), so we need a fallback regex
+  // bug fix: if no other plugin on the Etherpad instance returns a value on getLineHTMLForExport()
+  // hook, data-size=(...) won't be replaced by class=size:(...), so we need a fallback regex
   const fallbackRegex = `<span .*data-font-size=['|"]${size}['|"].*>${text}<\/span>`;
 
   return `${regex} || ${fallbackRegex}`;

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -8,7 +8,7 @@ const api = supertest(appUrl);
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 
 
-describe('export size styles to HTML', function () {
+describe('ep_font_size - export size styles to HTML', function () {
   let padID;
   let html;
 

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -105,14 +105,15 @@ describe('ep_font_size - export size styles to HTML', function () {
     it('returns HTML with strong and size, in any order', function (done) {
       api.get(getHTMLEndPointFor(padID))
           .expect((res) => {
-            const strongInsidesizeRegex = regexWithSize('8', '<strong>this is size 8 and bold<\/strong>');
-            const sizeInsideStrongRegex = `<strong>${regexWithSize('8', 'this is size 8 and bold')}<\/strong>`;
-            const expectedStrongInsidesize = new RegExp(strongInsidesizeRegex);
-            const expectedsizeInsideStrong = new RegExp(sizeInsideStrongRegex);
-
+            const txt = 'this is size 8 and bold';
+            const strongInside = new RegExp(regexWithSize('8', `<strong>${txt}</strong>`));
+            const sizeInside = new RegExp(`<strong>${regexWithSize('8', txt)}</strong>`);
             const html = res.body.data.html;
-            const foundsize = html.match(expectedStrongInsidesize) || html.match(expectedsizeInsideStrong);
-            if (!foundsize) throw new Error(`size not exported. Regex used: [${strongInsidesizeRegex} || ${sizeInsideStrongRegex}], html exported: ${html}`);
+            const foundsize = html.match(strongInside) || html.match(sizeInside);
+            if (!foundsize) {
+              throw new Error(`size not exported. Regex used: [${strongInside.source} || ` +
+                              `${sizeInside.source}], html exported: ${html}`);
+            }
           })
           .end(done);
     });
@@ -129,14 +130,15 @@ describe('ep_font_size - export size styles to HTML', function () {
     it('returns HTML with strong and size, in any order', function (done) {
       api.get(getHTMLEndPointFor(padID))
           .expect((res) => {
-            const strongInsidesizeRegex = regexWithSize('8', '<strong>this is size 8 and bold<\/strong>');
-            const sizeInsideStrongRegex = `<strong>${regexWithSize('8', 'this is size 8 and bold')}<\/strong>`;
-            const expectedStrongInsidesize = new RegExp(strongInsidesizeRegex);
-            const expectedsizeInsideStrong = new RegExp(sizeInsideStrongRegex);
-
+            const txt = 'this is size 8 and bold';
+            const strongInside = new RegExp(regexWithSize('8', `<strong>${txt}</strong>`));
+            const sizeInside = new RegExp(`<strong>${regexWithSize('8', txt)}</strong>`);
             const html = res.body.data.html;
-            const foundsize = html.match(expectedStrongInsidesize) || html.match(expectedsizeInsideStrong);
-            if (!foundsize) throw new Error(`size not exported. Regex used: [${strongInsidesizeRegex} || ${sizeInsideStrongRegex}], html exported: ${html}`);
+            const foundsize = html.match(strongInside) || html.match(sizeInside);
+            if (!foundsize) {
+              throw new Error(`size not exported. Regex used: [${strongInside.source} || ` +
+                              `${sizeInside.source}], html exported: ${html}`);
+            }
           })
           .end(done);
     });

--- a/static/tests/frontend/specs/l10n.js
+++ b/static/tests/frontend/specs/l10n.js
@@ -1,51 +1,49 @@
 describe('ep_font_size - Select font-size dropdown localization', function () {
-    //create a new pad with comment before each test run
-    beforeEach(function(cb){
-      helper.newPad(function() {
-        changeEtherpadLanguageTo('fr', cb);
-      });
-      this.timeout(60000);
+  // create a new pad with comment before each test run
+  beforeEach(function (cb) {
+    helper.newPad(() => {
+      changeEtherpadLanguageTo('fr', cb);
     });
-
-    // ensure we go back to English to avoid breaking other tests:
-    after(function(cb){
-      changeEtherpadLanguageTo('en', cb);
-    });
-
-    it("Localizes dropdown when Etherpad language is changed", function(done) {
-      const optionTranslations = {
-        "ep_font_size.size": "Taille"
-      }
-      let chrome$ = helper.padChrome$;
-      const $option = chrome$("#editbar").find('#font-size').find('option').first();
-
-      expect($option.text()).to.be(optionTranslations[$option.attr('data-l10n-id')]);
-
-      return done();
-    });
-
-    const changeEtherpadLanguageTo = function(lang, callback) {
-      const boldTitles = {
-        'en' : 'Bold (Ctrl+B)',
-        'fr' : 'Gras (Ctrl+B)'
-      };
-      const chrome$ = helper.padChrome$;
-
-      //click on the settings button to make settings visible
-      const $settingsButton = chrome$(".buttonicon-settings");
-      $settingsButton.click();
-
-      //select the language
-      const $language = chrome$("#languagemenu");
-      $language.val(lang);
-      $language.change();
-
-      // hide settings again
-      $settingsButton.click();
-
-      helper.waitFor(function() {
-        return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
-      })
-      .done(callback);
-    }
+    this.timeout(60000);
   });
+
+  // ensure we go back to English to avoid breaking other tests:
+  after(function (cb) {
+    changeEtherpadLanguageTo('en', cb);
+  });
+
+  it('Localizes dropdown when Etherpad language is changed', function (done) {
+    const optionTranslations = {
+      'ep_font_size.size': 'Taille',
+    };
+    const chrome$ = helper.padChrome$;
+    const $option = chrome$('#editbar').find('#font-size').find('option').first();
+
+    expect($option.text()).to.be(optionTranslations[$option.attr('data-l10n-id')]);
+
+    return done();
+  });
+
+  const changeEtherpadLanguageTo = function (lang, callback) {
+    const boldTitles = {
+      en: 'Bold (Ctrl+B)',
+      fr: 'Gras (Ctrl+B)',
+    };
+    const chrome$ = helper.padChrome$;
+
+    // click on the settings button to make settings visible
+    const $settingsButton = chrome$('.buttonicon-settings');
+    $settingsButton.click();
+
+    // select the language
+    const $language = chrome$('#languagemenu');
+    $language.val(lang);
+    $language.change();
+
+    // hide settings again
+    $settingsButton.click();
+
+    helper.waitFor(() => chrome$('.buttonicon-bold').parent()[0].title == boldTitles[lang])
+        .done(callback);
+  };
+});

--- a/static/tests/frontend/specs/l10n.js
+++ b/static/tests/frontend/specs/l10n.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('ep_font_size - Select font-size dropdown localization', function () {
   // create a new pad with comment before each test run
   beforeEach(function (cb) {

--- a/static/tests/frontend/specs/l10n.js
+++ b/static/tests/frontend/specs/l10n.js
@@ -26,7 +26,7 @@ describe('ep_font_size - Select font-size dropdown localization', function () {
     return done();
   });
 
-  const changeEtherpadLanguageTo = function (lang, callback) {
+  const changeEtherpadLanguageTo = (lang, callback) => {
     const boldTitles = {
       en: 'Bold (Ctrl+B)',
       fr: 'Gras (Ctrl+B)',
@@ -45,7 +45,7 @@ describe('ep_font_size - Select font-size dropdown localization', function () {
     // hide settings again
     $settingsButton.click();
 
-    helper.waitFor(() => chrome$('.buttonicon-bold').parent()[0].title == boldTitles[lang])
+    helper.waitFor(() => chrome$('.buttonicon-bold').parent()[0].title === boldTitles[lang])
         .done(callback);
   };
 });

--- a/static/tests/frontend/specs/l10n.js
+++ b/static/tests/frontend/specs/l10n.js
@@ -1,4 +1,4 @@
-describe("Select font-size dropdown localization", function(){
+describe('ep_font_size - Select font-size dropdown localization', function () {
     //create a new pad with comment before each test run
     beforeEach(function(cb){
       helper.newPad(function() {

--- a/static/tests/frontend/specs/l10n.js
+++ b/static/tests/frontend/specs/l10n.js
@@ -1,6 +1,29 @@
 'use strict';
 
 describe('ep_font_size - Select font-size dropdown localization', function () {
+  const changeEtherpadLanguageTo = (lang, callback) => {
+    const boldTitles = {
+      en: 'Bold (Ctrl+B)',
+      fr: 'Gras (Ctrl+B)',
+    };
+    const chrome$ = helper.padChrome$;
+
+    // click on the settings button to make settings visible
+    const $settingsButton = chrome$('.buttonicon-settings');
+    $settingsButton.click();
+
+    // select the language
+    const $language = chrome$('#languagemenu');
+    $language.val(lang);
+    $language.change();
+
+    // hide settings again
+    $settingsButton.click();
+
+    helper.waitFor(() => chrome$('.buttonicon-bold').parent()[0].title === boldTitles[lang])
+        .done(callback);
+  };
+
   // create a new pad with comment before each test run
   beforeEach(function (cb) {
     helper.newPad(() => {
@@ -25,27 +48,4 @@ describe('ep_font_size - Select font-size dropdown localization', function () {
 
     return done();
   });
-
-  const changeEtherpadLanguageTo = (lang, callback) => {
-    const boldTitles = {
-      en: 'Bold (Ctrl+B)',
-      fr: 'Gras (Ctrl+B)',
-    };
-    const chrome$ = helper.padChrome$;
-
-    // click on the settings button to make settings visible
-    const $settingsButton = chrome$('.buttonicon-settings');
-    $settingsButton.click();
-
-    // select the language
-    const $language = chrome$('#languagemenu');
-    $language.val(lang);
-    $language.change();
-
-    // hide settings again
-    $settingsButton.click();
-
-    helper.waitFor(() => chrome$('.buttonicon-bold').parent()[0].title === boldTitles[lang])
-        .done(callback);
-  };
 });

--- a/static/tests/frontend/specs/test.js
+++ b/static/tests/frontend/specs/test.js
@@ -21,9 +21,7 @@ describe('Set Font size and ensure its removed properly', function () {
     const inner$ = helper.padInner$;
 
     let $firstTextElement = inner$('div').first();
-    const $editorContainer = chrome$('#editorcontainer');
 
-    const $editorContents = inner$('div');
     $firstTextElement.sendkeys('foo');
     $firstTextElement.sendkeys('{selectall}');
 

--- a/static/tests/frontend/specs/test.js
+++ b/static/tests/frontend/specs/test.js
@@ -1,4 +1,4 @@
-describe('Set Font size and ensure its removed properly', function () {
+describe('ep_font_size - Set Font size and ensure its removed properly', function () {
   // Tests still to do
   // Ensure additional chars keep the same formatting
   // Ensure heading value is properly set when caret is placed on font size changed content

--- a/static/tests/frontend/specs/test.js
+++ b/static/tests/frontend/specs/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('ep_font_size - Set Font size and ensure its removed properly', function () {
   // Tests still to do
   // Ensure additional chars keep the same formatting


### PR DESCRIPTION
Many commits:
* Delete commented-out and unused code
* Define functions directly on `exports`
* Factor out duplicated size list
* Generate size options via new `range()` function
* Delete redundant jQuery import
* Fix selector for the font size drop-down
* tests: Prefix top-level `describe` with the plugin name
* lint: Bump eslint-config-etherpad to 1.0.13
* lint: Set node version and `peerDependencies` in `package.json`
* lint: Run `eslint --fix`
* lint: Add `'use strict';` everywhere
* lint: Consistently use `hookName` for hook functions
* lint: Tweak code to fix ESLint errors
* lint: Wrap long lines
* lint: Fix easy ESLint errors
* lint: Move functions so they are defined above their use
* lint: Run ESLint check in pull requests and before publish
* Delete some obsolete comments
* Minor readability improvements
