### PR TITLE
Fix: return focus to editor after toolbar selection

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -13,6 +13,7 @@ exports.postAceInit = (hookName, context) => {
         ace.ace_doInsertsizes(intValue);
       }, 'insertsize', true);
       hs.val('dummy');
+      context.ace.focus();
     }
   });
   $('.font_size').hover(() => {


### PR DESCRIPTION
## Summary

Focus was lost from the editor after selecting from the toolbar dropdown. Added `context.ace.focus()` after the selection is applied so users can keep typing immediately.

Same fix as ether/ep_headings2#149.

## Test plan

- [ ] Select from the dropdown — cursor should remain in the editor
- [ ] Verify selection still applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)