### PR TITLE
Add aria-label for screen reader accessibility

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -13,6 +13,7 @@ exports.postAceInit = (hookName, context) => {
         ace.ace_doInsertsizes(intValue);
       }, 'insertsize', true);
       hs.val('dummy');
+      context.ace.focus();
     }
   });
   $('.font_size').hover(() => {

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,6 +1,9 @@
 <li class="separator acl-write"></li>
 <li class="acl-write">
-    <select id="font-size" class="size-selection">
+    <select id="font-size" class="size-selection"
+            aria-label="Font size"
+            data-l10n-id="ep_font_size.size"
+            data-l10n-attr="aria-label">
         <option value="dummy" selected data-l10n-id="ep_font_size.size">Font Size</option>
         <option value="0">8</option>
         <option value="1">9</option>


### PR DESCRIPTION
## Summary

Adds `aria-label` to toolbar elements for screen reader accessibility, following the pattern established in ep_headings2.

## Test plan

- [ ] Screen reader announces the control label correctly
- [ ] Plugin functions normally after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)