### PR TITLE
Refactor: use ep_plugin_helpers for attribute pipeline and templates

### DIFF
--- a/exportHTML.js
+++ b/exportHTML.js
@@ -1,20 +1,13 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const {inlineAttributeExport} = require('ep_plugin_helpers/attributes-server');
 
-// Add the props to be supported in export
-exports.exportHtmlAdditionalTagsWithData = async (hookName, pad) => {
-  const ret = [];
-  pad.pool.eachAttrib((k, v) => { if (k === 'font-size') ret.push([k, v]); });
-  return ret;
-};
+const sizeExport = inlineAttributeExport({
+  attr: 'font-size',
+  exportCssFile: 'ep_font_size/static/css/size.css',
+  exportDataAttr: 'data-font-size',
+});
 
-// Include CSS for HTML export
-exports.stylesForExport =
-    async (hookName, padId) => eejs.require('ep_font_size/static/css/size.css');
-
-exports.getLineHTMLForExport = async (hookName, context) => {
-  // Replace data-size="foo" with class="font-size:x".
-  context.lineContent = context.lineContent.replace(
-      /data-font-size=["|']([0-9a-zA-Z]+)["|']/gi, 'class="font-size:$1"');
-};
+exports.exportHtmlAdditionalTagsWithData = sizeExport.exportHtmlAdditionalTagsWithData;
+exports.stylesForExport = sizeExport.stylesForExport;
+exports.getLineHTMLForExport = sizeExport.getLineHTMLForExport;

--- a/index.js
+++ b/index.js
@@ -1,27 +1,20 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
 const settingsModule = require('ep_etherpad-lite/node/utils/Settings');
 const settings = settingsModule.default || settingsModule;
+const {template, rawHTML} = require('ep_plugin_helpers');
+const eejs = require('ep_etherpad-lite/node/eejs/');
 const shared = require('./static/js/shared');
 
-exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
-  if (JSON.stringify(settings.toolbar).indexOf('fontSize') > -1) {
-    return cb();
-  }
-  args.content += eejs.require('ep_font_size/templates/editbarButtons.ejs');
-  return cb();
-};
+exports.eejsBlock_editbarMenuLeft = template('ep_font_size/templates/editbarButtons.ejs', {
+  skip: () => JSON.stringify(settings.toolbar).indexOf('fontSize') > -1,
+});
 
-exports.eejsBlock_dd_format = (hookName, args, cb) => {
-  args.content += eejs.require('ep_font_size/templates/fileMenu.ejs');
-  return cb();
-};
+exports.eejsBlock_dd_format = template('ep_font_size/templates/fileMenu.ejs');
 
-exports.eejsBlock_timesliderStyles = (hookName, args, cb) => {
-  args.content += `<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`;
-  return cb();
-};
+exports.eejsBlock_timesliderStyles = rawHTML(
+  `<style>${eejs.require('ep_font_size/static/css/size.css')}</style>`
+);
 
 exports.padInitToolbar = (hookName, args, cb) => {
   const toolbar = args.toolbar;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "type": "individual",
     "url": "https://etherpad.org/"
   },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.2.0"
+  },
   "devDependencies": {
     "eslint": "^8.57.1",
     "eslint-config-etherpad": "^4.0.4",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,8 +1,13 @@
 'use strict';
 
+const {inlineAttribute} = require('ep_plugin_helpers/attributes');
 const shared = require('./shared');
 
-// Bind the event handler to the toolbar buttons
+const fontSize = inlineAttribute({attr: 'font-size'});
+
+exports.aceAttribsToClasses = fontSize.aceAttribsToClasses;
+exports.aceCreateDomLine = fontSize.aceCreateDomLine;
+
 exports.postAceInit = (hookName, context) => {
   const hs = $('#font-size, select.size-selection');
   hs.on('change', function () {
@@ -20,36 +25,12 @@ exports.postAceInit = (hookName, context) => {
     $('.submenu > .size-selection').attr('size', 6);
     $('.submenu > #font-size').attr('size', 6);
   });
-  $('.font-size-icon').click(() => {
+  $('.font-size-icon').on('click', () => {
     $('#font-size').toggle();
   });
 };
 
-exports.aceAttribsToClasses = (hookName, context) => {
-  if (context.key.indexOf('font-size:') !== -1) {
-    const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.key);
-    return [`font-size:${size[1]}`];
-  }
-  if (context.key === 'font-size') {
-    return [`font-size:${context.value}`];
-  }
-};
-
-exports.aceCreateDomLine = (hookName, context) => {
-  const cls = context.cls;
-  const [, sizesType] = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(cls) || [];
-  if (sizesType == null) return [];
-  const tagIndex = shared.sizes.indexOf(sizesType);
-  if (tagIndex < 0) return [];
-  return [{
-    extraOpenTags: '',
-    extraCloseTags: '',
-    cls,
-  }];
-};
-
 exports.aceInitialized = (hookName, context) => {
-  // Passing a level >= 0 will set a sizes on the selected lines, level < 0 will remove it
   context.editorInfo.ace_doInsertsizes = (level) => {
     const {rep, documentAttributeManager} = context;
     if (!(rep.selStart && rep.selEnd)) return;
@@ -62,7 +43,7 @@ exports.aceInitialized = (hookName, context) => {
 exports.aceEditorCSS = () => ['ep_font_size/static/css/size.css'];
 
 exports.postToolbarInit = (hookName, context) => {
-  context.toolbar.registerCommand('fontSize', (buttonName, toolbar, item) => {
+  context.toolbar.registerCommand('fontSize', () => {
     $('#font-size').toggle();
   });
 };

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,17 +1,16 @@
 'use strict';
 
-// Starts at b, ends just before e, skipping s each time.
+const {inlineAttribute} = require('ep_plugin_helpers/attributes');
+
 const range = (b, e, s = 1) => [...Array(Math.ceil((e - b) / s)).keys()].map((x) => (x * s) + b);
 
-exports.collectContentPre = (hookName, context) => {
-  const size = /(?:^| )font-size:([A-Za-z0-9]*)/.exec(context.cls);
-  if (size && size[1]) {
-    context.cc.doAttrib(context.state, `font-size:${size[1]}`);
-  }
-};
-
-exports.sizes = []
+const sizes = []
     .concat(range(8, 20))
     .concat(range(20, 30, 2))
     .concat(range(30, 50, 5))
     .concat(range(50, 70, 10));
+
+const fontSize = inlineAttribute({attr: 'font-size'});
+
+exports.collectContentPre = fontSize.collectContentPre;
+exports.sizes = sizes;


### PR DESCRIPTION
## Summary

Same refactor as ether/ep_font_color#126 — replaces boilerplate with ep_plugin_helpers factories. Net -31 lines.

## Test plan

- [ ] Select text, apply size — renders correctly
- [ ] Export pad as HTML — sizes preserved
- [ ] Size dropdown reflects current selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)