### PR TITLE
Fix crash when settings.toolbar is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const eejs = require('ep_etherpad-lite/node/eejs/');
 const shared = require('./static/js/shared');
 
 exports.eejsBlock_editbarMenuLeft = template('ep_font_size/templates/editbarButtons.ejs', {
-  skip: () => JSON.stringify(settings.toolbar).indexOf('fontSize') > -1,
+  skip: () => settings.toolbar && JSON.stringify(settings.toolbar).indexOf('fontSize') > -1,
 });
 
 exports.eejsBlock_dd_format = template('ep_font_size/templates/fileMenu.ejs');


### PR DESCRIPTION
Fixes the same bug as ether/ep_font_color#113 — `JSON.stringify(settings.toolbar)` throws when toolbar is not configured in settings.json. Adds a null check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)