### PR TITLE
Fix: wrong data-key in file menu prevents font size submenu (#42)

### DIFF
--- a/templates/fileMenu.ejs
+++ b/templates/fileMenu.ejs
@@ -1,5 +1,5 @@
 <hr>
-<li><a href="#" data-key="align" class="font_size">Font size</a>
+<li><a href="#" data-key="fontSize" class="font_size" data-l10n-id="ep_font_size.size">Font size</a>
   <ul class="submenu">
     <select id="font-size" class="size-selection">
         <option value="dummy" selected data-l10n-id="ep_font_size.size">Font Size</option>


### PR DESCRIPTION
## Summary

Fixes #42 — the file menu template had `data-key="align"` (copy-paste from ep_align) instead of `data-key="fontSize"`, preventing the submenu from working.

Also added `data-l10n-id` for localization.

Note: #40 (export not working) should be fixed by the recent migration to `ep_plugin_helpers` (#117) which added proper `inlineAttributeExport` hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)