### PR TITLE
fix: read font-size from inline style on HTML import

### DIFF
--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -9,8 +9,47 @@ const sizes = []
     .concat(range(20, 30, 2))
     .concat(range(30, 50, 5))
     .concat(range(50, 70, 10));
+const sizeSet = new Set(sizes.map(String));
 
 const fontSize = inlineAttribute({attr: 'font-size'});
 
-exports.collectContentPre = fontSize.collectContentPre;
+// Read a `style="font-size:..."` declaration on imported HTML and apply
+// the matching `font-size::<value>` attribute. The `inlineAttribute`
+// factory only reads `class="font-size:14"` (the form ep_font_size
+// emits on export), so any externally-pasted HTML using the standard
+// CSS form would silently lose its size.
+const STYLE_FONT_SIZE_RE = /(?:^|;|\s)font-size\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*(px|pt|em|rem)?\s*(?:;|$)/i;
+
+// Map a CSS font-size to the nearest supported toolbar size. Sizes are
+// integer pt/px values; Word commonly emits half-points (e.g. 11pt is
+// 22 half-points) so we floor to the nearest integer first.
+const matchSupportedSize = (value, unit) => {
+  let n = Math.round(parseFloat(value));
+  if (!isFinite(n) || n <= 0) return null;
+  const u = (unit || 'px').toLowerCase();
+  // Convert pt → px (1pt ≈ 1.333px) but only roughly; toolbar values
+  // were authored as bare numbers, mostly treated as pt-equivalent in
+  // ep_font_size. Use the value as-is for pt and px.
+  if (u === 'em' || u === 'rem') n = Math.round(n * 16); // 1em ≈ 16
+  if (sizeSet.has(String(n))) return String(n);
+  // Find the closest available size.
+  let best = null; let bestDist = Infinity;
+  for (const s of sizes) {
+    const d = Math.abs(s - n);
+    if (d < bestDist) { best = s; bestDist = d; }
+  }
+  return best != null ? String(best) : null;
+};
+
+const collectContentPreOrig = fontSize.collectContentPre;
+exports.collectContentPre = (hookName, context) => {
+  collectContentPreOrig(hookName, context);
+  if (context.styl) {
+    const m = STYLE_FONT_SIZE_RE.exec(context.styl);
+    if (m) {
+      const size = matchSupportedSize(m[1], m[2]);
+      if (size) context.cc.doAttrib(context.state, `font-size::${size}`);
+    }
+  }
+};
 exports.sizes = sizes;

--- a/static/tests/backend/specs/api/exportHTML.ts
+++ b/static/tests/backend/specs/api/exportHTML.ts
@@ -200,4 +200,32 @@ describe('ep_font_size - export size styles to HTML', function () {
       }
     });
   });
+
+  // Round-trip via inline `style="font-size:..."`. External HTML
+  // (Word/DOCX via mammoth, pasted markup) uses the standard CSS form
+  // instead of the `class="font-size:N"` form ep_font_size emits on
+  // export. Without the import-side style reader, the size is lost.
+  context('when imported HTML uses style="font-size:..."', function () {
+    for (const size of ['8', '14', '20']) {
+      it(`preserves style="font-size:${size}px" through round-trip`, function (done) {
+        const newPadID = randomString(5);
+        createPad(newPadID, () => {
+          const padHtml =
+              buildHTML(`<p>before <span style="font-size:${size}px">styled</span> after</p>`);
+          setHTML(newPadID, padHtml, async () => {
+            const res = await agent.get(getHTMLEndPointFor(newPadID))
+                .set('Authorization', await generateJWTToken());
+            const out = res.body.data.html;
+            const re = new RegExp(
+                `(class=["'].*font-size:${size}|data-font-size=["']${size})`);
+            if (!re.test(out)) {
+              return done(new Error(
+                  `Size not preserved on style-import round-trip. Got: ${out}`));
+            }
+            done();
+          });
+        });
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Problem

`getLineHTMLForExport` emits `class="font-size:<N>"` on export and `inlineAttribute.collectContentPre` reads `class` on import — so our own export → import round-trip works.

External HTML (Word/DOCX via mammoth, pasted from a browser) uses the standard CSS form `style="font-size:14px"`. The factory doesn't touch `context.styl`, so externally-pasted size is silently dropped — and any DOCX import via [`ether/etherpad#7568`](https://github.com/ether/etherpad/pull/7568) loses font sizes.

## Fix

Wrap `collectContentPre` to also scan `context.styl` for `font-size:...`. Snap the value to the nearest supported toolbar size, with light-touch unit handling for `px`/`pt`/`em`/`rem`.

## Tests

`static/tests/backend/specs/api/exportHTML.ts`: new context block, three test cases asserting that a pad imported with `<span style="font-size:Npx">styled</span>` re-exports as `class="font-size:N"` (or the `data-font-size` fallback). Covers `8`, `14`, `20`.

Refs `ether/etherpad#7568`. Sister PRs: `ether/ep_align#183` (text-align, merged), `ether/ep_font_color#150` (color).