### PR TITLE
ci: switch pnpm/action-setup to packageManager-only

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Summary

`pnpm/action-setup@v6` errors with `ERR_PNPM_BAD_PM_VERSION` when both `version:` is set on the action and `packageManager:` is set in package.json — regardless of whether the values match. `ether/etherpad-lite`'s package.json declares `packageManager: pnpm@11.0.6`, so the conflict bites every plugin's CI.

This PR drops the `version:` pin so pnpm/action-setup@v6 reads the canonical version from `packageManager`. For test workflows that check out etherpad-lite into `./etherpad-lite/`, also adds `package_json_file: ./etherpad-lite/package.json` so the action can locate the file (since cwd has no package.json at install time).

Verified green on ether/ep_dynamic_default_content.