### PR TITLE
a11y: drop redundant hardcoded aria-label

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,9 +1,7 @@
 <li class="separator acl-write"></li>
 <li class="acl-write">
     <select id="font-size" class="size-selection"
-            aria-label="Font size"
-            data-l10n-id="ep_font_size.size"
-            data-l10n-attr="aria-label">
+            data-l10n-id="ep_font_size.size">
         <option value="dummy" selected data-l10n-id="ep_font_size.size">Font Size</option>
         <option value="0">8</option>
         <option value="1">9</option>


### PR DESCRIPTION
## Summary

Removes hardcoded `aria-label="…"` attributes from elements that already declare `data-l10n-id`. With `aria-label` set in the template, etherpad's html10n skips the auto-population path (`html10n.ts:665-678`) and leaves screen readers with the English label even when the user's UI language is something else.

After this PR, html10n populates `aria-label` from the localized translation on every `pad.applyLanguage()` call, marked with `data-l10n-aria-label="true"` so subsequent passes refresh it.

Also drops the `data-l10n-attr="aria-label"` attribute where present — that's a convention from a different localization library (e.g. fluent-dom), and etherpad's html10n does not read it. The auto-population in lines 665-678 is the etherpad mechanism.

Part of the fleet-wide plugin a11y/i18n sweep (Phase 3 of the modernization campaign; pilot: ether/ep_align#182).