### PR TITLE
a11y: mark <select> aria-label as html10n-managed (forward-compatible)

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,7 +1,8 @@
 <li class="separator acl-write"></li>
 <li class="acl-write">
     <select aria-label="Font size" id="font-size" class="size-selection"
-            data-l10n-id="ep_font_size.size">
+            data-l10n-id="ep_font_size.size"
+            data-l10n-aria-label="true">
         <option value="dummy" selected data-l10n-id="ep_font_size.size">Font Size</option>
         <option value="0">8</option>
         <option value="1">9</option>


### PR DESCRIPTION
## Summary

Adds `data-l10n-aria-label="true"` to toolbar `<select>` elements with `data-l10n-id`. After ether/etherpad#7713, html10n's aria-label auto-population covers form-control elements; the marker tells html10n it owns this attribute and may overwrite it with the localized string on every `pad.applyLanguage()` call.

**Forward-compatible, not a breaking change for users on older etherpad:**
- Older etherpad without the html10n fix doesn't reach the form-control aria-label path → the hardcoded English `aria-label` remains as a fallback (no regression).
- Newer etherpad with the html10n fix → html10n overwrites the aria-label with the localized translation on initial load and on language change.

Also drops `data-l10n-attr="aria-label"` — a no-op convention from a different localization library.