### PR TITLE
feat: migrate to ep_plugin_helpers/toolbar-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://etherpad.org/"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.2.7"
+    "ep_plugin_helpers": "^0.6.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {inlineAttribute} = require('ep_plugin_helpers/attributes');
+const {toolbarSelect} = require('ep_plugin_helpers/toolbar-select');
 const shared = require('./shared');
 
 const fontSize = inlineAttribute({attr: 'font-size'});
@@ -9,17 +10,11 @@ exports.aceAttribsToClasses = fontSize.aceAttribsToClasses;
 exports.aceCreateDomLine = fontSize.aceCreateDomLine;
 
 exports.postAceInit = (hookName, context) => {
-  const hs = $('#font-size, select.size-selection');
-  hs.on('change', function () {
-    const value = $(this).val();
-    const intValue = parseInt(value, 10);
-    if (!isNaN(intValue)) {
-      context.ace.callWithAce((ace) => {
-        ace.ace_doInsertsizes(intValue);
-      }, 'insertsize', true);
-      hs.val('dummy');
-      context.ace.focus();
-    }
+  toolbarSelect({
+    selector: '#font-size, select.size-selection',
+    context,
+    invoke: (ace, value) => ace.ace_doInsertsizes(value),
+    op: 'insertsize',
   });
   $('.font_size').hover(() => {
     $('.submenu > .size-selection').attr('size', 6);


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `<select>` change handler with the shared `toolbarSelect` helper from [ep_plugin_helpers#17](https://github.com/ether/ep_plugin_helpers/pull/17).

```diff
- const hs = $('#font-size, select.size-selection');
- hs.on('change', function () {
-   const value = $(this).val();
-   const intValue = parseInt(value, 10);
-   if (!isNaN(intValue)) {
-     context.ace.callWithAce((ace) => {
-       ace.ace_doInsertsizes(intValue);
-     }, 'insertsize', true);
-     hs.val('dummy');
-     context.ace.focus();
-   }
- });
+ toolbarSelect({
+   selector: '#font-size, select.size-selection',
+   context,
+   invoke: (ace, value) => ace.ace_doInsertsizes(value),
+   op: 'insertsize',
+ });
```

## Behavioral notes

- Same int coercion, same `callWithAce` op label, same `'dummy'` sentinel reset.
- The helper restores focus **unconditionally** (even on an unusable pick). The previous code only restored focus when the int coerce succeeded; on a no-op pick, focus stayed on the `<select>`. Restoring focus always is the WCAG-friendly default and matches what ep_headings2 already did.
- ep_plugin_helpers dep range bumped `^0.2.7 → ^0.6.0`.

## Status

**Draft** — depends on:
1. https://github.com/ether/ep_plugin_helpers/pull/17 merging
2. ep_plugin_helpers ≥ 0.6.0 published to npm

Refs https://github.com/ether/etherpad/issues/7255

🤖 Generated with [Claude Code](https://claude.com/claude-code)