### PR TITLE
fix(deps): bump ep_plugin_helpers range to ^0.6.1 (follow-up to #142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://etherpad.org/"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.6.0"
+    "ep_plugin_helpers": "^0.6.1"
   },
   "devDependencies": {
     "eslint": "^8.57.1",


### PR DESCRIPTION
Follow-up to https://github.com/ether/ep_font_size/pull/142.

Etherpad's plugin installer (live-plugin-manager-backed) resolves the dep range's **lower-bound version literally** — `^0.6.0` makes it ask npm for `ep_plugin_helpers@0.6.0`, which was never published. The ep_plugin_helpers auto-publish workflow bumped straight from `0.5.3` to `0.6.1` and skipped `0.6.0`, so:

```
Error: Version '^0.6.0 not found
```

CI on main has been red since #142 merged for this reason. Same fix being applied to ep_font_color#160 and ep_headings2#184. Anchor to the actual published version so the install resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)