### PR TITLE
chore(deps): regenerate pnpm-lock.yaml after ep_plugin_helpers bump

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       ep_plugin_helpers:
-        specifier: ^0.2.7
-        version: 0.2.7
+        specifier: ^0.6.1
+        version: 0.6.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -404,8 +404,8 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
-  ep_plugin_helpers@0.2.7:
-    resolution: {integrity: sha512-WgyI23UbpOu5o7tPE9GGBalS8Qo42ZH4DvqFf+WUFfKnyC0yDZ3+pdqYQUtTO2KNo1lG18RRlK3tX90DmE/haA==}
+  ep_plugin_helpers@0.6.2:
+    resolution: {integrity: sha512-CGWdFk6FG0Q0y1opoly+J4tkNpSOI2Tho4oOmaWCpMwgJxvdO4W/i5LIZQXLDSGoRCuAUKokd3H/fvEqTjztgw==}
     engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
@@ -1681,7 +1681,7 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
-  ep_plugin_helpers@0.2.7: {}
+  ep_plugin_helpers@0.6.2: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
## Why
The earlier bump of `ep_plugin_helpers` to `^0.6.1` in `package.json` was not accompanied by a `pnpm-lock.yaml` update. The release workflow (`.github/workflows/npmpublish.yml`) runs `pnpm i --frozen-lockfile` before the version bump, which fails with `ERR_PNPM_OUTDATED_LOCKFILE`. As a result no publish has run since that change landed, and fresh installs of this plugin still resolve `ep_plugin_helpers@0.5.3` from npm rather than the current `0.6.x` line — which means consumers miss ether/ep_plugin_helpers#19's correction of the misleading "Etherpad < 2.7.4" degradation warning.

## What
- Re-run `pnpm install` so the lockfile picks up the new manifest range.
- No other file should change.

Merging this PR triggers the release workflow on the next push to the default branch, which should now publish a fresh patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)