### PR TITLE
ci: bump pnpm/action-setup v5 → v6 in publish workflow

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -31,10 +31,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          # No `version:` — defer to packageManager in package.json so we
+          # don't trip "Multiple versions of pnpm specified" when an
+          # upstream checkout (etherpad-lite) pins a different pnpm via
+          # packageManager. See pnpm/action-setup#225.
           run_install: false
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Symptom
Every push to `main` since 2026-05-17 has failed `publish-npm`:

> ``Error: Multiple versions of pnpm specified:``
> ``  - version pnpm@11.1.2 in the package.json with the key "packageManager"``
> ``  - version 10 in the GitHub Action config with the key "version"``

So npm is still serving the pre-bump tarball (`0.4.109` with `^0.2.7` ep_plugin_helpers), which doesn't resolve to the current `ep_plugin_helpers@0.6.x` line.

## Fix
`pnpm/action-setup@v5` doesn't tolerate both inputs being set; `@v6` defers to `packageManager` in `package.json` when present. The other ether/* plugins (ep_align, ep_cursortrace, …) already use `@v6` with no `version:` override — match that convention here.

## Test plan
- [ ] CI green on this PR (test/backend/frontend)
- [ ] After merge, the release workflow successfully bumps + publishes a fresh patch version
- [ ] That new tarball ships with `ep_plugin_helpers: "^0.6.0"` in `dependencies` (already in main since #144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)